### PR TITLE
Add auth context and org structure view

### DIFF
--- a/backend/config/web.php
+++ b/backend/config/web.php
@@ -47,7 +47,9 @@ $config = [
             'showScriptName' => false,
             'enableStrictParsing' => false,
             'rules' => [
-                ['class' => 'yii\rest\UrlRule', 'controller' => ['task', 'result']],
+                ['class' => 'yii\rest\UrlRule', 'controller' => ['task', 'result', 'user', 'position']],
+                'POST auth/login' => 'auth/login',
+                'POST auth/logout' => 'auth/logout',
                 'GET task/by-date' => 'task/by-date',  // нове правило
             ],
         ],

--- a/backend/controllers/AuthController.php
+++ b/backend/controllers/AuthController.php
@@ -1,0 +1,44 @@
+<?php
+namespace app\controllers;
+
+use Yii;
+use yii\rest\Controller;
+use yii\web\Response;
+use yii\filters\Cors;
+use app\models\LoginForm;
+
+class AuthController extends Controller
+{
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+        $behaviors['corsFilter'] = [
+            'class' => Cors::class,
+            'cors' => [
+                'Origin' => ['*'],
+                'Access-Control-Request-Method' => ['POST', 'OPTIONS'],
+                'Access-Control-Allow-Credentials' => true,
+                'Access-Control-Max-Age' => 3600,
+                'Access-Control-Request-Headers' => ['*'],
+            ],
+        ];
+        return $behaviors;
+    }
+
+    public function actionLogin()
+    {
+        Yii::$app->response->format = Response::FORMAT_JSON;
+        $model = new LoginForm();
+        $model->load(Yii::$app->request->post(), '');
+        if ($model->login()) {
+            return ['success' => true, 'user' => Yii::$app->user->identity];
+        }
+        return ['success' => false, 'errors' => $model->errors];
+    }
+
+    public function actionLogout()
+    {
+        Yii::$app->user->logout();
+        return ['success' => true];
+    }
+}

--- a/backend/controllers/PositionController.php
+++ b/backend/controllers/PositionController.php
@@ -1,0 +1,26 @@
+<?php
+namespace app\controllers;
+
+use yii\rest\ActiveController;
+use yii\filters\Cors;
+
+class PositionController extends ActiveController
+{
+    public $modelClass = 'app\models\Position';
+
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+        $behaviors['corsFilter'] = [
+            'class' => Cors::class,
+            'cors' => [
+                'Origin' => ['*'],
+                'Access-Control-Request-Method' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+                'Access-Control-Allow-Credentials' => true,
+                'Access-Control-Max-Age' => 3600,
+                'Access-Control-Request-Headers' => ['*'],
+            ],
+        ];
+        return $behaviors;
+    }
+}

--- a/backend/controllers/UserController.php
+++ b/backend/controllers/UserController.php
@@ -1,0 +1,26 @@
+<?php
+namespace app\controllers;
+
+use yii\rest\ActiveController;
+use yii\filters\Cors;
+
+class UserController extends ActiveController
+{
+    public $modelClass = 'app\models\User';
+
+    public function behaviors()
+    {
+        $behaviors = parent::behaviors();
+        $behaviors['corsFilter'] = [
+            'class' => Cors::class,
+            'cors' => [
+                'Origin' => ['*'],
+                'Access-Control-Request-Method' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+                'Access-Control-Allow-Credentials' => true,
+                'Access-Control-Max-Age' => 3600,
+                'Access-Control-Request-Headers' => ['*'],
+            ],
+        ];
+        return $behaviors;
+    }
+}

--- a/backend/migrations/m250718_000000_create_position_table.php
+++ b/backend/migrations/m250718_000000_create_position_table.php
@@ -1,0 +1,32 @@
+<?php
+use yii\db\Migration;
+
+class m250718_000000_create_position_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%position}}', [
+            'id' => $this->primaryKey(),
+            'organization_id' => $this->integer()->notNull(),
+            'name' => $this->string(255)->notNull(),
+            'description' => $this->text(),
+            'created_at' => $this->integer(),
+            'updated_at' => $this->integer(),
+        ]);
+
+        $this->addForeignKey(
+            'fk_position_organization',
+            '{{%position}}',
+            'organization_id',
+            '{{%organization}}',
+            'id',
+            'CASCADE'
+        );
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_position_organization', '{{%position}}');
+        $this->dropTable('{{%position}}');
+    }
+}

--- a/backend/migrations/m250718_000100_create_user_position_table.php
+++ b/backend/migrations/m250718_000100_create_user_position_table.php
@@ -1,0 +1,39 @@
+<?php
+use yii\db\Migration;
+
+class m250718_000100_create_user_position_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->createTable('{{%user_position}}', [
+            'user_id' => $this->integer()->notNull(),
+            'position_id' => $this->integer()->notNull(),
+            'PRIMARY KEY(user_id, position_id)',
+        ]);
+
+        $this->addForeignKey(
+            'fk_user_position_user',
+            '{{%user_position}}',
+            'user_id',
+            '{{%user}}',
+            'id',
+            'CASCADE'
+        );
+
+        $this->addForeignKey(
+            'fk_user_position_position',
+            '{{%user_position}}',
+            'position_id',
+            '{{%position}}',
+            'id',
+            'CASCADE'
+        );
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_user_position_position', '{{%user_position}}');
+        $this->dropForeignKey('fk_user_position_user', '{{%user_position}}');
+        $this->dropTable('{{%user_position}}');
+    }
+}

--- a/backend/migrations/m250718_000200_add_manager_to_position_table.php
+++ b/backend/migrations/m250718_000200_add_manager_to_position_table.php
@@ -1,0 +1,25 @@
+<?php
+use yii\db\Migration;
+
+class m250718_000200_add_manager_to_position_table extends Migration
+{
+    public function safeUp()
+    {
+        $this->addColumn('{{%position}}', 'manager_id', $this->integer());
+        $this->addForeignKey(
+            'fk_position_manager',
+            '{{%position}}',
+            'manager_id',
+            '{{%position}}',
+            'id',
+            'SET NULL',
+            'CASCADE'
+        );
+    }
+
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_position_manager', '{{%position}}');
+        $this->dropColumn('{{%position}}', 'manager_id');
+    }
+}

--- a/backend/models/Position.php
+++ b/backend/models/Position.php
@@ -1,0 +1,43 @@
+<?php
+namespace app\models;
+
+use yii\db\ActiveRecord;
+
+class Position extends ActiveRecord
+{
+    public static function tableName()
+    {
+        return 'position';
+    }
+
+    public function rules()
+    {
+        return [
+            [['organization_id', 'name'], 'required'],
+            [['organization_id', 'manager_id', 'created_at', 'updated_at'], 'integer'],
+            [['description'], 'string'],
+            [['name'], 'string', 'max' => 255],
+        ];
+    }
+
+    public function getManager()
+    {
+        return $this->hasOne(self::class, ['id' => 'manager_id']);
+    }
+
+    public function getSubordinates()
+    {
+        return $this->hasMany(self::class, ['manager_id' => 'id']);
+    }
+
+    public function getOrganization()
+    {
+        return $this->hasOne(Organization::class, ['id' => 'organization_id']);
+    }
+
+    public function getUsers()
+    {
+        return $this->hasMany(User::class, ['id' => 'user_id'])
+            ->viaTable('user_position', ['position_id' => 'id']);
+    }
+}

--- a/backend/models/User.php
+++ b/backend/models/User.php
@@ -1,13 +1,84 @@
 <?php
-
 namespace app\models;
 
+use Yii;
 use yii\db\ActiveRecord;
+use yii\web\IdentityInterface;
 
-class User extends ActiveRecord
+class User extends ActiveRecord implements IdentityInterface
 {
     public static function tableName()
     {
         return 'user';
+    }
+
+    public function rules()
+    {
+        return [
+            [['organization_id', 'username'], 'required'],
+            [['organization_id', 'status', 'created_at', 'updated_at'], 'integer'],
+            [['username', 'email', 'password_hash', 'auth_key'], 'string', 'max' => 255],
+            [['first_name', 'last_name', 'telegram_username'], 'string', 'max' => 100],
+            [['telegram_id'], 'string', 'max' => 50],
+            [['role'], 'string', 'max' => 50],
+            [['username'], 'unique'],
+            [['email'], 'unique'],
+        ];
+    }
+
+    public static function findIdentity($id)
+    {
+        return static::findOne($id);
+    }
+
+    public static function findIdentityByAccessToken($token, $type = null)
+    {
+        return static::findOne(['auth_key' => $token]);
+    }
+
+    public static function findByUsername($username)
+    {
+        return static::findOne(['username' => $username]);
+    }
+
+    public function validatePassword($password)
+    {
+        return Yii::$app->security->validatePassword($password, $this->password_hash);
+    }
+
+    public function setPassword($password)
+    {
+        $this->password_hash = Yii::$app->security->generatePasswordHash($password);
+    }
+
+    public function generateAuthKey()
+    {
+        $this->auth_key = Yii::$app->security->generateRandomString();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getAuthKey()
+    {
+        return $this->auth_key;
+    }
+
+    public function validateAuthKey($authKey)
+    {
+        return $this->auth_key === $authKey;
+    }
+
+    public function getOrganization()
+    {
+        return $this->hasOne(Organization::class, ['id' => 'organization_id']);
+    }
+
+    public function getPositions()
+    {
+        return $this->hasMany(Position::class, ['id' => 'position_id'])
+            ->viaTable('user_position', ['user_id' => 'id']);
     }
 }

--- a/frontend/src/components/layout/Header/Header.css
+++ b/frontend/src/components/layout/Header/Header.css
@@ -19,6 +19,10 @@
     display: flex;
     align-items: center;
 }
+.header-left .org-name {
+    margin-left: 10px;
+    font-weight: bold;
+}
 
 /* Центр: пошук */
 .header-center {

--- a/frontend/src/components/layout/Header/Header.jsx
+++ b/frontend/src/components/layout/Header/Header.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from "react";
 import "./Header.css";
 import { FiMenu } from "react-icons/fi"; // стильна іконка меню
+import { useAuth } from "../../../context/AuthContext";
 
 export default function Header({ onToggleMenu }) {
     const [userMenuOpen, setUserMenuOpen] = useState(false);
+    const { user, logout } = useAuth();
 
     return (
         <header className="app-header">
@@ -12,6 +14,7 @@ export default function Header({ onToggleMenu }) {
                 <button className="menu-btn" onClick={onToggleMenu} title="Toggle menu">
                     <FiMenu size={22} color="#fff" />
                 </button>
+                {user && <span className="org-name">{user.organization?.name}</span>}
             </div>
 
             {/* Центр: пошук */}
@@ -29,7 +32,7 @@ export default function Header({ onToggleMenu }) {
                         <ul>
                             <li>Профіль</li>
                             <li>Налаштування</li>
-                            <li className="logout">Вихід</li>
+                            <li className="logout" onClick={logout}>Вихід</li>
                         </ul>
                     </div>
                 )}

--- a/frontend/src/components/layout/Sidebar/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar/Sidebar.jsx
@@ -26,7 +26,7 @@ export default function Sidebar({ isOpen, onToggle }) {
                 <nav>
                     <ul>
                         <li>
-                            <NavLink to="/" activeclassname="active">
+                            <NavLink to="/results" activeclassname="active">
                                 <FiBarChart2 className="menu-icon" />
                                 {isOpen && <span className="menu-text">Результати</span>}
                             </NavLink>

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,0 +1,59 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import axios from "axios";
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+    const [user, setUser] = useState(null);
+
+    useEffect(() => {
+        const stored = localStorage.getItem("user");
+        if (stored) {
+            try {
+                setUser(JSON.parse(stored));
+            } catch (e) {
+                console.error("Failed to parse stored user", e);
+            }
+        }
+    }, []);
+
+    const login = async (username, password) => {
+        try {
+            const res = await axios.post(
+                "https://tasks.fineko.space/backend/web/index.php?r=auth/login",
+                { username, password }
+            );
+            if (res.data && res.data.success) {
+                setUser(res.data.user);
+                localStorage.setItem("user", JSON.stringify(res.data.user));
+                return true;
+            }
+        } catch (e) {
+            console.error("Login error", e);
+        }
+        return false;
+    };
+
+    const logout = async () => {
+        try {
+            await axios.post(
+                "https://tasks.fineko.space/backend/web/index.php?r=auth/logout"
+            );
+        } catch (e) {
+            // ignore
+        }
+        setUser(null);
+        localStorage.removeItem("user");
+    };
+
+    return (
+        <AuthContext.Provider value={{ user, login, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+}
+
+export function useAuth() {
+    return useContext(AuthContext);
+}
+

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/global.css";
+import { AuthProvider } from "./context/AuthContext";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
-root.render(<App />);
+root.render(
+    <AuthProvider>
+        <App />
+    </AuthProvider>
+);

--- a/frontend/src/modules/auth/pages/LoginPage.jsx
+++ b/frontend/src/modules/auth/pages/LoginPage.jsx
@@ -1,18 +1,47 @@
-import React from "react";
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import Layout from "../../../components/layout/Layout";
+import { useAuth } from "../../../context/AuthContext";
 
 export default function LoginPage() {
+    const { login } = useAuth();
+    const navigate = useNavigate();
+    const [username, setUsername] = useState("");
+    const [password, setPassword] = useState("");
+    const [error, setError] = useState("");
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        const ok = await login(username, password);
+        if (ok) {
+            navigate("/");
+        } else {
+            setError("Невірний логін або пароль");
+        }
+    };
+
     return (
         <Layout>
             <h2>Авторизація</h2>
-            <form>
+            {error && <p style={{ color: "red" }}>{error}</p>}
+            <form onSubmit={handleSubmit}>
                 <div>
                     <label>Логін:</label>
-                    <input type="text" placeholder="Введіть логін" />
+                    <input
+                        type="text"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                        placeholder="Введіть логін"
+                    />
                 </div>
                 <div>
                     <label>Пароль:</label>
-                    <input type="password" placeholder="Введіть пароль" />
+                    <input
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        placeholder="Введіть пароль"
+                    />
                 </div>
                 <button type="submit">Увійти</button>
             </form>

--- a/frontend/src/modules/orgStructure/pages/OrgStructurePage.jsx
+++ b/frontend/src/modules/orgStructure/pages/OrgStructurePage.jsx
@@ -1,11 +1,63 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Layout from "../../../components/layout/Layout";
+import axios from "axios";
 
 export default function OrgStructurePage() {
+    const [tree, setTree] = useState([]);
+
+    useEffect(() => {
+        async function load() {
+            try {
+                const [posRes, userRes] = await Promise.all([
+                    axios.get(
+                        "https://tasks.fineko.space/backend/web/index.php?r=position"
+                    ),
+                    axios.get(
+                        "https://tasks.fineko.space/backend/web/index.php?r=user"
+                    ),
+                ]);
+                const positions = posRes.data;
+                const users = userRes.data;
+                const map = {};
+                positions.forEach((p) => {
+                    map[p.id] = { ...p, users: [], children: [] };
+                });
+                users.forEach((u) => {
+                    (u.positions || []).forEach((pos) => {
+                        if (map[pos.id]) map[pos.id].users.push(u);
+                    });
+                });
+                const roots = [];
+                positions.forEach((p) => {
+                    const node = map[p.id];
+                    if (p.manager_id && map[p.manager_id]) {
+                        map[p.manager_id].children.push(node);
+                    } else {
+                        roots.push(node);
+                    }
+                });
+                setTree(roots);
+            } catch (e) {
+                console.error("Failed to load org structure", e);
+            }
+        }
+        load();
+    }, []);
+
+    const renderNode = (node) => (
+        <li key={node.id}>
+            <strong>{node.name}</strong>
+            {node.users.map((u) => (
+                <div key={u.id}>{u.username}</div>
+            ))}
+            {node.children.length > 0 && <ul>{node.children.map(renderNode)}</ul>}
+        </li>
+    );
+
     return (
         <Layout>
             <h2>Організаційна структура</h2>
-            <p>Тут буде відображатися оргструктура компанії.</p>
+            <ul>{tree.map(renderNode)}</ul>
         </Layout>
     );
 }

--- a/frontend/src/modules/results/pages/ResultsPage.jsx
+++ b/frontend/src/modules/results/pages/ResultsPage.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import Layout from "../../../components/layout/Layout";
+
+export default function ResultsPage() {
+    return (
+        <Layout>
+            <h2>Список результатів</h2>
+            <p>Тут будуть відображатися результати.</p>
+        </Layout>
+    );
+}

--- a/frontend/src/routes/AppRouter.jsx
+++ b/frontend/src/routes/AppRouter.jsx
@@ -2,19 +2,56 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import HomePage from "../pages/HomePage";
 import TasksPage from "../modules/tasks/pages/TasksPage";
+import DailyTasksPage from "../modules/tasks/pages/DailyTasksPage";
+import ResultsPage from "../modules/results/pages/ResultsPage";
 import OrgStructurePage from "../modules/orgStructure/pages/OrgStructurePage";
 import LoginPage from "../modules/auth/pages/LoginPage";
 import NotFound from "../pages/NotFound";
-import DailyTasksPage from "../modules/tasks/pages/DailyTasksPage";
+import { useAuth } from "../context/AuthContext";
+import { Navigate } from "react-router-dom";
 
 export default function AppRouter() {
+    const { user } = useAuth();
+
+    const RequireAuth = ({ children }) =>
+        user ? children : <Navigate to="/auth" replace />;
+
     return (
         <Router>
             <Routes>
-                <Route path="/" element={<HomePage />} />
-                <Route path="/tasks" element={<DailyTasksPage />} />
-                <Route path="/org-structure" element={<OrgStructurePage />} />
                 <Route path="/auth" element={<LoginPage />} />
+                <Route
+                    path="/"
+                    element={
+                        <RequireAuth>
+                            <HomePage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/tasks"
+                    element={
+                        <RequireAuth>
+                            <DailyTasksPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/results"
+                    element={
+                        <RequireAuth>
+                            <ResultsPage />
+                        </RequireAuth>
+                    }
+                />
+                <Route
+                    path="/org-structure"
+                    element={
+                        <RequireAuth>
+                            <OrgStructurePage />
+                        </RequireAuth>
+                    }
+                />
                 <Route path="*" element={<NotFound />} />
             </Routes>
         </Router>


### PR DESCRIPTION
## Summary
- support manager hierarchy for positions
- create login context and wrap app with AuthProvider
- show organization name in header and allow logout
- enforce login for routes and add results page
- build organization structure page from API

## Testing
- `php -l backend/models/Position.php`
- `php -l backend/migrations/m250718_000200_add_manager_to_position_table.php`
- `node --check frontend/src/context/AuthContext.js`
- `node --check frontend/src/routes/AppRouter.jsx` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_688b98d8152083329aa276e192c75fea