### PR TITLE
Switch frontend requests to /api URLs

### DIFF
--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -20,7 +20,7 @@ export function AuthProvider({ children }) {
     const login = async (username, password) => {
         try {
             const res = await axios.post(
-                "https://tasks.fineko.space/backend/web/index.php?r=auth/login",
+                "https://tasks.fineko.space/api/auth/login",
                 { username, password }
             );
             if (res.data && res.data.success) {
@@ -37,7 +37,7 @@ export function AuthProvider({ children }) {
     const logout = async () => {
         try {
             await axios.post(
-                "https://tasks.fineko.space/backend/web/index.php?r=auth/logout"
+                "https://tasks.fineko.space/api/auth/logout"
             );
         } catch (e) {
             // ignore

--- a/frontend/src/modules/orgStructure/pages/OrgStructurePage.jsx
+++ b/frontend/src/modules/orgStructure/pages/OrgStructurePage.jsx
@@ -10,10 +10,10 @@ export default function OrgStructurePage() {
             try {
                 const [posRes, userRes] = await Promise.all([
                     axios.get(
-                        "https://tasks.fineko.space/backend/web/index.php?r=position"
+                        "https://tasks.fineko.space/api/position"
                     ),
                     axios.get(
-                        "https://tasks.fineko.space/backend/web/index.php?r=user"
+                        "https://tasks.fineko.space/api/user"
                     ),
                 ]);
                 const positions = posRes.data;

--- a/frontend/src/modules/tasks/pages/DailyTasksPage.jsx
+++ b/frontend/src/modules/tasks/pages/DailyTasksPage.jsx
@@ -32,7 +32,7 @@ export default function DailyTasksPage() {
 
         axios
             .get(
-                `https://tasks.fineko.space/backend/web/index.php?r=task/filter&${params.toString()}`
+                `https://tasks.fineko.space/api/task/filter?${params.toString()}`
             )
             .then((res) => {
                 if (res.data && res.data.tasks) {
@@ -66,7 +66,7 @@ export default function DailyTasksPage() {
     const deleteTask = async (id) => {
         try {
             await axios.delete(
-                `https://tasks.fineko.space/backend/web/index.php?r=task/delete&id=${id}`
+                `https://tasks.fineko.space/api/task/delete?id=${id}`
             );
             setTasks((prev) => prev.filter((task) => task.id !== id));
         } catch (err) {
@@ -80,7 +80,7 @@ export default function DailyTasksPage() {
     const updateTaskField = async (id, field, value) => {
         try {
             const res = await axios.patch(
-                `https://tasks.fineko.space/backend/web/index.php?r=task/update-field&id=${id}`,
+                `https://tasks.fineko.space/api/task/update-field?id=${id}`,
                 { field, value }
             );
 


### PR DESCRIPTION
## Summary
- update frontend API calls to use `/api` paths for nicer URLs

## Testing
- `CI=true npm test --prefix frontend --if-present` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_688bbc9b9bbc8332aa8fed1c0abc3821