### PR TITLE
Fix static assets path for React build

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,6 +18,8 @@ RewriteCond %{REQUEST_URI} ^/api/
 RewriteRule ^api/(.*)$ backend/web/index.php [L]
 
 # Видаємо React build з папки frontend/build
+# Спочатку обробляємо статичні ресурси
+RewriteRule ^static/(.*)$ frontend/build/static/$1 [L]
 # Якщо файл або директорія існує — віддаємо як є
 RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d


### PR DESCRIPTION
## Summary
- ensure static files are served from `frontend/build/static` in `.htaccess`

## Testing
- `npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_688bbd10c67883328bc6473acc6709d9