### PR TITLE
Add API docs and test endpoint

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -1,0 +1,49 @@
+# API Documentation
+
+This document lists available API endpoints for the project.
+
+## Test Endpoint
+- `GET /test` – returns a confirmation that the API is working.
+
+## Authentication
+- `POST /auth/login` – log in a user.
+- `POST /auth/logout` – log out the current user.
+- `POST /auth/telegram-login` – log in via Telegram.
+
+## Tasks
+### RESTful
+- `GET /tasks` – list tasks.
+- `GET /tasks/{id}` – view a task.
+- `POST /tasks` – create a task.
+- `PUT /tasks/{id}` – update a task.
+- `PATCH /tasks/{id}` – partially update a task.
+- `DELETE /tasks/{id}` – delete a task.
+
+### Additional
+- `GET /task/filter` – filter tasks by various parameters.
+- `DELETE /task/delete?id={id}` – delete a task (alternative endpoint).
+- `PATCH /task/update-field?id={id}` – update a single field of a task.
+
+## Results
+- `GET /results` – list results.
+- `GET /results/{id}` – view a result.
+- `POST /results` – create a result.
+- `PUT /results/{id}` – update a result.
+- `PATCH /results/{id}` – partially update a result.
+- `DELETE /results/{id}` – delete a result.
+
+## Users
+- `GET /users` – list users.
+- `GET /users/{id}` – view a user.
+- `POST /users` – create a user.
+- `PUT /users/{id}` – update a user.
+- `PATCH /users/{id}` – partially update a user.
+- `DELETE /users/{id}` – delete a user.
+
+## Positions
+- `GET /positions` – list positions.
+- `GET /positions/{id}` – view a position.
+- `POST /positions` – create a position.
+- `PUT /positions/{id}` – update a position.
+- `PATCH /positions/{id}` – partially update a position.
+- `DELETE /positions/{id}` – delete a position.

--- a/backend/config/web.php
+++ b/backend/config/web.php
@@ -52,6 +52,7 @@ $config = [
                 'POST auth/logout' => 'auth/logout',
                 'POST auth/telegram-login' => 'auth/telegram-login',
                 'GET task/by-date' => 'task/by-date',  // нове правило
+                'GET test' => 'test/index',
             ],
         ],
         'response' => [

--- a/backend/controllers/TestController.php
+++ b/backend/controllers/TestController.php
@@ -1,0 +1,31 @@
+<?php
+namespace app\controllers;
+
+use yii\web\Controller;
+use yii\web\Response;
+use yii\filters\Cors;
+
+class TestController extends Controller
+{
+    public function behaviors()
+    {
+        return [
+            'corsFilter' => [
+                'class' => Cors::class,
+                'cors' => [
+                    'Origin' => ['*'],
+                    'Access-Control-Request-Method' => ['GET', 'OPTIONS'],
+                    'Access-Control-Allow-Credentials' => true,
+                    'Access-Control-Max-Age' => 3600,
+                    'Access-Control-Request-Headers' => ['*'],
+                ],
+            ],
+        ];
+    }
+
+    public function actionIndex()
+    {
+        \Yii::$app->response->format = Response::FORMAT_JSON;
+        return ['message' => 'API is working successfully'];
+    }
+}


### PR DESCRIPTION
## Summary
- create `TestController` with a simple health check action
- expose the test endpoint via url manager
- document all API endpoints in `API_DOCUMENTATION.md`

## Testing
- `php -l backend/controllers/TestController.php`
- `php -l backend/config/web.php`

------
https://chatgpt.com/codex/tasks/task_e_688bc22daa50833291bf392da176243f