### PR TITLE
Add password reset via email

### DIFF
--- a/backend/config/web.php
+++ b/backend/config/web.php
@@ -51,6 +51,8 @@ $config = [
                 'POST auth/login' => 'auth/login',
                 'POST auth/logout' => 'auth/logout',
                 'POST auth/telegram-login' => 'auth/telegram-login',
+                'POST auth/request-password-reset' => 'auth/request-password-reset',
+                'POST auth/reset-password' => 'auth/reset-password',
                 'GET task/by-date' => 'task/by-date',  // нове правило
                 'GET test' => 'test/index',
             ],

--- a/backend/mail/passwordResetToken.php
+++ b/backend/mail/passwordResetToken.php
@@ -1,0 +1,11 @@
+<?php
+/* @var $this yii\web\View */
+/* @var $user app\models\User */
+
+$resetLink = "https://ftasks.local/reset-password?token={$user->password_reset_token}";
+?>
+Hello <?= $user->username ?>,
+
+Follow the link below to reset your password:
+
+<?= $resetLink ?>

--- a/backend/migrations/m250801_000100_add_password_reset_token_to_user_table.php
+++ b/backend/migrations/m250801_000100_add_password_reset_token_to_user_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles adding columns to table `{{%user}}`.
+ */
+class m250801_000100_add_password_reset_token_to_user_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->addColumn('{{%user}}', 'password_reset_token', $this->string()->unique());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropColumn('{{%user}}', 'password_reset_token');
+    }
+}


### PR DESCRIPTION
## Summary
- allow users to request password reset links via email
- support resetting password using emailed token
- store password reset token for each user

## Testing
- `composer install` *(fails: requires GitHub token)*
- `vendor/bin/codecept run` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688c0ffd4e7883328ab7c124a359f4b9