### PR TITLE
feat: include csrf token in auth requests

### DIFF
--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -3,6 +3,15 @@ import axios from "axios";
 
 const AuthContext = createContext(null);
 
+function getCsrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    if (meta) {
+        return meta.getAttribute('content');
+    }
+    const match = document.cookie.match(/(^|;\s*)_csrf=([^;]+)/);
+    return match ? decodeURIComponent(match[2]) : "";
+}
+
 export function AuthProvider({ children }) {
     const [user, setUser] = useState(null);
 
@@ -21,7 +30,11 @@ export function AuthProvider({ children }) {
         try {
             const res = await axios.post(
                 "https://tasks.fineko.space/api/auth/login",
-                { username, password }
+                { username, password },
+                {
+                    headers: { "X-CSRF-Token": getCsrfToken() },
+                    withCredentials: true,
+                }
             );
             if (res.data && res.data.success) {
                 setUser(res.data.user);
@@ -37,7 +50,12 @@ export function AuthProvider({ children }) {
     const logout = async () => {
         try {
             await axios.post(
-                "https://tasks.fineko.space/api/auth/logout"
+                "https://tasks.fineko.space/api/auth/logout",
+                {},
+                {
+                    headers: { "X-CSRF-Token": getCsrfToken() },
+                    withCredentials: true,
+                }
             );
         } catch (e) {
             // ignore


### PR DESCRIPTION
## Summary
- read CSRF token from meta tag or cookie
- attach token and credentials to login/logout requests

## Testing
- `npm test --prefix frontend -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/routes/AppRouter.jsx')*
- `NODE_OPTIONS=--experimental-vm-modules npm test --prefix frontend -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/routes/AppRouter.jsx')*

------
https://chatgpt.com/codex/tasks/task_e_688c15a38c3c8332a65c8800409970b6