### PR TITLE
feat: add csrf token handling

### DIFF
--- a/backend/config/web.php
+++ b/backend/config/web.php
@@ -15,6 +15,9 @@ $config = [
         'request' => [
             // !!! insert a secret key in the following (if it is empty) - this is required by cookie validation
             'cookieValidationKey' => 'RnmH64wG8bRABrW3rP9QUI0kEDBdcCJz',
+            'parsers' => [
+                'application/json' => 'yii\web\JsonParser',
+            ],
         ],
         'cache' => [
             'class' => 'yii\caching\FileCache',
@@ -47,14 +50,27 @@ $config = [
             'showScriptName' => false,
             'enableStrictParsing' => false,
             'rules' => [
-                ['class' => 'yii\rest\UrlRule', 'controller' => ['task', 'result', 'user', 'position']],
-                'POST auth/login' => 'auth/login',
-                'POST auth/logout' => 'auth/logout',
-                'POST auth/telegram-login' => 'auth/telegram-login',
-                'POST auth/request-password-reset' => 'auth/request-password-reset',
-                'POST auth/reset-password' => 'auth/reset-password',
-                'GET task/by-date' => 'task/by-date',  // нове правило
-                'GET test' => 'test/index',
+                [
+                    'class' => 'yii\rest\UrlRule',
+                    'controller' => ['auth'],
+                    'prefix' => 'api',
+                    'pluralize' => false,
+                    'extraPatterns' => [
+                        'POST login' => 'login',
+                        'POST logout' => 'logout',
+                        'POST telegram-login' => 'telegram-login',
+                        'POST request-password-reset' => 'request-password-reset',
+                        'POST reset-password' => 'reset-password',
+                        'GET csrf' => 'csrf',
+                    ],
+                ],
+                [
+                    'class' => 'yii\rest\UrlRule',
+                    'controller' => ['task', 'result', 'user', 'position'],
+                    'prefix' => 'api',
+                ],
+                'GET api/task/by-date' => 'task/by-date',  // нове правило
+                'GET api/test' => 'test/index',
             ],
         ],
         'response' => [
@@ -63,7 +79,7 @@ $config = [
                 $response = $event->sender;
                 $response->headers->set('Access-Control-Allow-Origin', '*');
                 $response->headers->set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-                $response->headers->set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+                $response->headers->set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-CSRF-Token');
             },
         ],
         'as cors' => [

--- a/backend/controllers/AuthController.php
+++ b/backend/controllers/AuthController.php
@@ -10,6 +10,13 @@ use app\models\User;
 
 class AuthController extends Controller
 {
+    public $enableCsrfValidation = true;
+    public function beforeAction($action)
+    {
+        Yii::$app->response->format = Response::FORMAT_JSON;
+        return parent::beforeAction($action);
+    }
+
     public function behaviors()
     {
         $behaviors = parent::behaviors();
@@ -17,20 +24,25 @@ class AuthController extends Controller
             'class' => Cors::class,
             'cors' => [
                 'Origin' => ['*'],
-                'Access-Control-Request-Method' => ['POST', 'OPTIONS'],
+                'Access-Control-Request-Method' => ['GET', 'POST', 'OPTIONS'],
                 'Access-Control-Allow-Credentials' => true,
                 'Access-Control-Max-Age' => 3600,
+                'Access-Control-Allow-Headers' => ['Content-Type', 'Authorization', 'X-CSRF-Token'],
                 'Access-Control-Request-Headers' => ['*'],
             ],
         ];
         return $behaviors;
     }
 
+    public function actionCsrf()
+    {
+        return ['csrfToken' => Yii::$app->request->getCsrfToken()];
+    }
+
     public function actionLogin()
     {
-        Yii::$app->response->format = Response::FORMAT_JSON;
         $model = new LoginForm();
-        $model->load(Yii::$app->request->post(), '');
+        $model->load(Yii::$app->request->bodyParams, '');
         if ($model->login()) {
             return ['success' => true, 'user' => Yii::$app->user->identity];
         }
@@ -45,8 +57,7 @@ class AuthController extends Controller
 
     public function actionTelegramLogin()
     {
-        Yii::$app->response->format = Response::FORMAT_JSON;
-        $id = Yii::$app->request->post('telegram_id');
+        $id = Yii::$app->request->bodyParams['telegram_id'] ?? null;
         if (!$id) {
             return ['success' => false, 'message' => 'telegram_id required'];
         }
@@ -61,8 +72,7 @@ class AuthController extends Controller
 
     public function actionRequestPasswordReset()
     {
-        Yii::$app->response->format = Response::FORMAT_JSON;
-        $email = Yii::$app->request->post('email');
+        $email = Yii::$app->request->bodyParams['email'] ?? null;
         if (!$email) {
             return ['success' => false, 'message' => 'Email required'];
         }
@@ -84,9 +94,8 @@ class AuthController extends Controller
 
     public function actionResetPassword()
     {
-        Yii::$app->response->format = Response::FORMAT_JSON;
-        $token = Yii::$app->request->post('token');
-        $password = Yii::$app->request->post('password');
+        $token = Yii::$app->request->bodyParams['token'] ?? null;
+        $password = Yii::$app->request->bodyParams['password'] ?? null;
         if (!$token || !$password) {
             return ['success' => false, 'message' => 'Token and password required'];
         }

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import axios from "axios";
+import { getCsrfToken } from "../utils/csrf";
 
 const AuthContext = createContext(null);
 
@@ -19,9 +20,14 @@ export function AuthProvider({ children }) {
 
     const login = async (username, password) => {
         try {
+            const token = await getCsrfToken();
             const res = await axios.post(
                 "https://tasks.fineko.space/api/auth/login",
-                { username, password }
+                { username, password },
+                {
+                    withCredentials: true,
+                    headers: { "X-CSRF-Token": token || "" },
+                }
             );
             if (res.data && res.data.success) {
                 setUser(res.data.user);
@@ -36,8 +42,14 @@ export function AuthProvider({ children }) {
 
     const logout = async () => {
         try {
+            const token = await getCsrfToken();
             await axios.post(
-                "https://tasks.fineko.space/api/auth/logout"
+                "https://tasks.fineko.space/api/auth/logout",
+                {},
+                {
+                    withCredentials: true,
+                    headers: { "X-CSRF-Token": token || "" },
+                }
             );
         } catch (e) {
             // ignore

--- a/frontend/src/utils/csrf.js
+++ b/frontend/src/utils/csrf.js
@@ -1,0 +1,18 @@
+export async function getCsrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    if (meta) {
+        return meta.getAttribute('content');
+    }
+    const match = document.cookie.match(/(^|;)\s*_csrf=([^;]+)/);
+    if (match) {
+        return decodeURIComponent(match[2]);
+    }
+    const res = await fetch('https://tasks.fineko.space/api/auth/csrf', {
+        credentials: 'include'
+    });
+    if (res.ok) {
+        const data = await res.json();
+        return data.csrfToken;
+    }
+    return null;
+}


### PR DESCRIPTION
## Summary
- parse JSON request bodies and expose auth routes under a dedicated `/api` REST rule
- allow `X-CSRF-Token` and provide `/api/auth/csrf` endpoint for clients
- include CSRF tokens in frontend login and logout requests

## Testing
- `npm test --prefix frontend -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/routes/AppRouter.jsx')*
- `NODE_OPTIONS=--experimental-vm-modules npm test --prefix frontend -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/routes/AppRouter.jsx')*

------
https://chatgpt.com/codex/tasks/task_e_688c15a38c3c8332a65c8800409970b6